### PR TITLE
fix unusable Line Plot due to undefined QtCore

### DIFF
--- a/argos/inspector/pgplugins/pghistlutitem.py
+++ b/argos/inspector/pgplugins/pghistlutitem.py
@@ -6,6 +6,7 @@
 
 
 #from pyqtgraph.Qt import QtWidgets, QtCore
+from pyqtgraph.Qt import QtCore
 from argos.qt import QtWidgets
 from pyqtgraph.graphicsItems.GraphicsWidget import GraphicsWidget
 from pyqtgraph.graphicsItems.ViewBox import *


### PR DESCRIPTION
This change allows `Line Plot` to work.